### PR TITLE
fixed failing test cases

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "makefile.extensionOutputFolder": "./.vscode",
+    "go.testFlags": ["-v"]
+}

--- a/static/app.js
+++ b/static/app.js
@@ -1,11 +1,25 @@
 const Controller = {
   search: (ev) => {
     ev.preventDefault();
+    page = 0;
     const form = document.getElementById("form");
     const data = Object.fromEntries(new FormData(form));
-    const response = fetch(`/search?q=${data.query}`).then((response) => {
+    const response = fetch(`/search?q=${data.query}&p=${page}`).then((response) => {
       response.json().then((results) => {
         Controller.updateTable(results);
+        page = page + 1
+      });
+    });
+  },
+
+  loadmore: (ev) => {
+    ev.preventDefault();
+    const form = document.getElementById("form");
+    const data = Object.fromEntries(new FormData(form));
+    const response = fetch(`/search?q=${data.query}&p=${page}`).then((response) => {
+      response.json().then((results) => {
+        Controller.updateTable(results);
+        page = page + 1
       });
     });
   },
@@ -16,9 +30,16 @@ const Controller = {
     for (let result of results) {
       rows.push(`<tr><td>${result}</td></tr>`);
     }
-    table.innerHTML = rows;
+    if (page == 0){
+      table.innerHTML = rows;
+    } else {
+      table.innerHTML = table.innerHTML + rows;
+    }
   },
 };
 
+var page = 0;
 const form = document.getElementById("form");
+const button = document.getElementById("load-more");
 form.addEventListener("submit", Controller.search);
+button.addEventListener("click", Controller.loadmore);

--- a/static/index.html
+++ b/static/index.html
@@ -21,7 +21,7 @@
     <tbody id="table-body"></tbody>
   </table>
   </p>
-  <button>Load More</button>
+  <button id="load-more">Load More</button>
   <script src="app.js"></script>
 </body>
 


### PR DESCRIPTION
Fixed following test cases in golang server

Test 2: Expects results for the case-sensitive query.
The suffixarray package indexes the words as we passed. To ensure case insensitivity, I converted the entire doc to lowercase before passing it to the index function. Additionally, I converted the query string to lowercase before calling the lookup function to avoid any case-sensitive failures.

Test 3: Expects 20 results for the query `drunk`.
The suffixarray package returns the complete list of indexes it matches. To restrict the output to the first 20 results, I included a constant with a value of 20 and returned the subset if the indexes had more than 20 results.

Fixed following test cases in JS

Test 3: Expects load more to append results.To enable `load more`, I have received a page number from the client and implemented pagination logic on the server side. The page number will be reset when the client initiates a new search and will automatically increment each time the "load more" function is triggered.